### PR TITLE
Updated for putty commit 0a0a1c0

### DIFF
--- a/italics-0a0a1c0.patch
+++ b/italics-0a0a1c0.patch
@@ -1,0 +1,200 @@
+--- putty-0a0a1c0-orig/putty.h	2017-10-31 10:43:03.530533321 -0400
++++ putty-0a0a1c0/putty.h	2017-10-31 11:37:41.608384618 -0400
+@@ -104,6 +104,7 @@
+  */
+ #define UCSWIDE	     0xDFFF
+ 
++#define ATTR_ITALIC  0x1000000U
+ #define ATTR_NARROW  0x0800000U
+ #define ATTR_WIDE    0x0400000U
+ #define ATTR_BOLD    0x0040000U
+--- putty-0a0a1c0-orig/terminal.c	2017-10-31 10:43:06.474488972 -0400
++++ putty-0a0a1c0/terminal.c	2017-10-31 11:44:46.053047484 -0400
+@@ -3895,6 +3895,10 @@
+ 				    compatibility(OTHER);
+ 				    term->curr_attr |= ATTR_DIM;
+ 				    break;
++				  case 3:	/* enable italics */
++				    compatibility(ANSI);
++				    term->curr_attr |= ATTR_ITALIC;
++				    break;
+ 				  case 21:	/* (enable double underline) */
+ 				    compatibility(OTHER);
+ 				  case 4:	/* enable underline */
+@@ -3930,6 +3934,10 @@
+ 				    compatibility2(OTHER, VT220);
+ 				    term->curr_attr &= ~(ATTR_BOLD | ATTR_DIM);
+ 				    break;
++				  case 23:	/* disable italics */
++				    compatibility(ANSI);
++				    term->curr_attr &= ~ATTR_ITALIC;
++				    break;
+ 				  case 24:	/* disable underline */
+ 				    compatibility2(OTHER, VT220);
+ 				    term->curr_attr &= ~ATTR_UNDER;
+--- putty-0a0a1c0-orig/windows/window.c	2017-10-31 10:43:12.771394112 -0400
++++ putty-0a0a1c0/windows/window.c	2017-10-31 12:01:09.171366887 -0400
+@@ -172,17 +172,18 @@
+ #define FONT_BOLD 1
+ #define FONT_UNDERLINE 2
+ #define FONT_BOLDUND 3
+-#define FONT_WIDE	0x04
+-#define FONT_HIGH	0x08
+-#define FONT_NARROW	0x10
+-
+-#define FONT_OEM 	0x20
+-#define FONT_OEMBOLD 	0x21
+-#define FONT_OEMUND 	0x22
+-#define FONT_OEMBOLDUND 0x23
++#define FONT_ITALIC 4
++#define FONT_WIDE	0x08
++#define FONT_HIGH	0x10
++#define FONT_NARROW	0x20
++
++#define FONT_OEM 	0x40
++#define FONT_OEMBOLD 	0x41
++#define FONT_OEMUND 	0x42
++#define FONT_OEMBOLDUND 0x43
+ 
+-#define FONT_MAXNO 	0x40
+-#define FONT_SHIFT	5
++#define FONT_MAXNO 	0x4F
++#define FONT_SHIFT	6
+ static HFONT fonts[FONT_MAXNO];
+ static LOGFONT lfont;
+ static int fontflag[FONT_MAXNO];
+@@ -194,6 +195,7 @@
+     UND_LINE, UND_FONT
+ } und_mode;
+ static int descent;
++static int use_italics;
+ 
+ #define NCFGCOLOURS 22
+ #define NEXTCOLOURS 240
+@@ -1505,13 +1507,13 @@
+     font_width = pick_width;
+ 
+     quality = conf_get_int(conf, CONF_font_quality);
+-#define f(i,c,w,u) \
+-    fonts[i] = CreateFont (font_height, font_width, 0, 0, w, FALSE, u, FALSE, \
++#define f(i,c,w,u,t) \
++    fonts[i] = CreateFont (font_height, font_width, 0, 0, w, t, u, FALSE, \
+ 			   c, OUT_DEFAULT_PRECIS, \
+ 		           CLIP_DEFAULT_PRECIS, FONT_QUALITY(quality), \
+ 			   FIXED_PITCH | FF_DONTCARE, font->name)
+ 
+-    f(FONT_NORMAL, font->charset, fw_dontcare, FALSE);
++    f(FONT_NORMAL, font->charset, fw_dontcare, FALSE, FALSE);
+ 
+     SelectObject(hdc, fonts[FONT_NORMAL]);
+     GetTextMetrics(hdc, &tm);
+@@ -1555,7 +1557,57 @@
+ 	ucsdata.dbcs_screenfont = (cpinfo.MaxCharSize > 1);
+     }
+ 
+-    f(FONT_UNDERLINE, font->charset, fw_dontcare, TRUE);
++    /* Check whether italic face is acceptable... */
++    f(FONT_ITALIC, font->charset, fw_dontcare, FALSE, TRUE);
++
++    {
++    LPOUTLINETEXTMETRICA regularOtm, italicOtm;
++
++    use_italics = 0;
++
++    i = GetOutlineTextMetricsA(hdc, 0, NULL);
++    if (i > 0) {
++        regularOtm = (LPOUTLINETEXTMETRICA)safemalloc(1, i);
++        regularOtm->otmSize = sizeof(OUTLINETEXTMETRICA);
++        if (GetOutlineTextMetricsA(hdc, i, regularOtm)) {
++        /* Now get the italic version */
++        SelectObject(hdc, fonts[FONT_ITALIC]);
++        i = GetOutlineTextMetricsA(hdc, 0, NULL);
++        if (i > 0) {
++            italicOtm = (LPOUTLINETEXTMETRICA)safemalloc(1, i);
++            italicOtm->otmSize = sizeof(OUTLINETEXTMETRICA);
++            if (GetOutlineTextMetricsA(hdc, i, italicOtm)) {
++            /* Compare... */
++            char *regStyle = (char*)regularOtm + (int)regularOtm->otmpStyleName;
++            char *itaStyle = (char*)italicOtm + (int)italicOtm->otmpStyleName;
++
++            /* Weed out "italic" fonts that...
++                - Do not specify an italic slant (probably just the regular font)
++                - Have the same style as the regular font.  Then it *is* just the regular
++                font with a linear transformation.
++                - Report the style name of "Oblique".
++
++                My experience is these a) don't look very good b) tend to overhang the
++                next character and get cut off during paints... which doesn't look very good. */
++            if (strcmp(regStyle, itaStyle) && stricmp(itaStyle, "Oblique") && italicOtm->otmItalicAngle != 0) {
++                use_italics = 1;
++            }
++            }
++
++            safefree(italicOtm);
++        }
++        }
++
++        safefree(regularOtm);
++    }
++
++    if (!use_italics) {
++        DeleteObject(fonts[FONT_ITALIC]);
++        fonts[FONT_ITALIC] = NULL;
++    }
++    }
++
++    f(FONT_UNDERLINE, font->charset, fw_dontcare, TRUE, FALSE);
+ 
+     /*
+      * Some fonts, e.g. 9-pt Courier, draw their underlines
+@@ -1606,7 +1658,7 @@
+     }
+ 
+     if (bold_font_mode == BOLD_FONT) {
+-	f(FONT_BOLD, font->charset, fw_bold, FALSE);
++	f(FONT_BOLD, font->charset, fw_bold, FALSE, FALSE);
+     }
+ #undef f
+ 
+@@ -1647,7 +1699,7 @@
+ {
+     int basefont;
+     int fw_dontcare, fw_bold, quality;
+-    int c, u, w, x;
++    int c, u, w, x, t;
+     char *s;
+     FontSpec *font;
+ 
+@@ -1673,6 +1725,7 @@
+     u = FALSE;
+     s = font->name;
+     x = font_width;
++	t = FALSE;
+ 
+     if (fontno & FONT_WIDE)
+ 	x *= 2;
+@@ -1684,12 +1737,14 @@
+ 	w = fw_bold;
+     if (fontno & FONT_UNDERLINE)
+ 	u = TRUE;
++	if (fontno & FONT_ITALIC && use_italics)
++	t = TRUE;
+ 
+     quality = conf_get_int(conf, CONF_font_quality);
+ 
+     fonts[fontno] =
+ 	CreateFont(font_height * (1 + !!(fontno & FONT_HIGH)), x, 0, 0, w,
+-		   FALSE, u, FALSE, c, OUT_DEFAULT_PRECIS,
++		   t, u, FALSE, c, OUT_DEFAULT_PRECIS,
+ 		   CLIP_DEFAULT_PRECIS, FONT_QUALITY(quality),
+ 		   DEFAULT_PITCH | FF_DONTCARE, s);
+ 
+@@ -3510,6 +3565,8 @@
+ 	nfont |= FONT_BOLD;
+     if (und_mode == UND_FONT && (attr & ATTR_UNDER))
+ 	nfont |= FONT_UNDERLINE;
++	if (attr & ATTR_ITALIC)
++	nfont |= FONT_ITALIC;
+     another_font(nfont);
+     if (!fonts[nfont]) {
+ 	if (nfont & FONT_UNDERLINE)


### PR DESCRIPTION
Firstly, thank you very much for introducing Italics support.  It seems to be working splendidly for me thus far (tested with various command-line output, and Vim 8.0 with italics enabled and the excellent gruvbox colorscheme installed).

This patch works against upstream PuTTY commit 0a0a1c0 (latest as of 2017-Oct-20).  This mainly interesting because some of the more recent commits now include truecolor support.